### PR TITLE
add OSM Scout Server to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ data into vector tiles that can be rendered dynamically.
 - [Tegola](https://github.com/terranodo/tegola) - A MVT server written in pure Go that supports serving tiles from a PostGIS data provider.
 - [t-rex](https://github.com/pka/t-rex/) - MVT server in a single executable written in Rust. Serves tiles from PostGIS supporting custom tile grids.
 - [postserve](https://github.com/openmaptiles/postserve) - A small Python based tileserver using ST_AsMVT and ST_AsMVTGeom to generate vector tiles on the fly. Designed for use with PostGIS 2.4 and the OpenMapTiles project
+- [OSM Scout Server](https://github.com/rinigus/osmscout-server) - Maps server providing vector and raster tiles, geocoder, and router. Designed to be used on Linux (mobile and PC) to provide offline maps; written in C++
 - [SpatialServer (PGRestAPI)](https://github.com/spatialdev/PGRestAPI) - A multi-purpose GeoSpatial NodeJS web server created at [SpatialDev](http://spatialdev.com) that not only serves MBTiles stuffed with vector tiles, it can also cut vector tiles on the fly from a PostGIS database. :warning: [_No longer maintained_](https://github.com/spatialdev/PGRestAPI/issues/142#issuecomment-231132808).
 
 ## Low-level utilities


### PR DESCRIPTION
Starting with the version 1.2.0 (released yesterday), OSM Scout Server provides Mapbox GL vector tiles for map applications. The tiles are packaged to cover the world and allow user to download regions of interest and use them on device in offline mode. The server is developed mainly to run on Sailfish OS, but can be used on Linux PCs in CLI mode.