### PR TITLE
add link to Mapbox-vector-tiles-basic-js-renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ data into vector tiles that can be rendered dynamically.
 * [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/) - Draw vector tile layers as part of your web map. Rendering done via `mapbox-gl-js` integration.
 * [mapscii](https://github.com/rastapasta/mapscii) - A Vector Tile to Braille and ASCII renderer for xterm-compatible terminals
 * [Unofficial Mapbox GL Native bindings for Qt QML](https://github.com/rinigus/mapbox-gl-qml) - Qt QML bindings for Qt 5.6 and higher.
+* [Mapbox-vector-tiles-basic-js-renderer](https://github.com/landtechnologies/Mapbox-vector-tiles-basic-js-renderer) - A fork of mapbox-gl-js giving you full control over rendering of specific tiles, also provides vector tile overlay for google maps.
 
 ### Applications / Command line tools
 


### PR DESCRIPTION
I have just open sourced the project linked to here. Note that although it is a fork of mapbox-gl-js it offers two very different features, namely letting you render source MVT tiles outside of a proper map and rendering MVTs on top of a google map.