### PR TITLE
Add orb library, mvt <-> geojson in go

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ data into vector tiles that can be rendered dynamically.
 - [cached-vector-tile](https://github.com/developmentseed/cached-vector-tile) - An alternative implementation of the vector-tile-js interface, backed by plain JS objects/arrays rather than parsed-on-demand protobuf data. Trades away memory efficiency for faster feature.loadGeometry() calls.
 - [tilegrinder](https://github.com/rastapasta/tilegrinder) - A helper library for applying a data altering function on each vector tile in an MBTiles, using the native protobuf wrapper for de- and encoding, recompressing the results and storing them either in an MBTiles or as single files.
 - [SwiftVectorTiles](https://github.com/manimaul/SwiftVectorTiles) - A Swift encoder for vector tiles according to the Mapbox vector tile spec.
+- [orb](https://github.com/paulmach/orb) - A Go geometry library with mvt <-> geojson support.
 
 ## Clients
 


### PR DESCRIPTION
[orb](https://github.com/paulmach/orb) is a package for working with 2d geometry. It is a successor to [go.geo](https://github.com/paulmach/go.geo) and [go.geojson](https://github.com/paulmach/go.geojson).  It supports going between geojson and mvt with helpers to project between the coordinate spaces.

The readme here has the details https://github.com/paulmach/orb/tree/master/encoding/mvt