### PR TITLE
Add Baremaps reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ data into vector tiles that can be rendered dynamically.
 - [mapbox-gl-inspect](https://github.com/lukasmartinelli/mapbox-gl-inspect) - Plugin for Mapbox GL JS to view the view and inspect VT features.
 - [Mapbox MVT Chrome Extension](https://chrome.google.com/webstore/detail/mapbox-mvt/mfikcokdfehaofebfhoehbajfgbofdpk) - Google Chrome extension that parses loaded vector tiles on the fly, shows short statistics and shows each vector tile as GeoJSON
 - [Fresco](https://github.com/go-spatial/fresco) - is an open source Mapbox Vector Tile Style editor.
-
+- [Baremaps](https://www.baremaps.com/) - An open source pipeline for producing Mapbox vector tiles from OpenStreetMap with Postgis and Java.
 
 ## CLI Utilities
 


### PR DESCRIPTION
Baremaps is an open source pipeline for producing Mapbox vector tiles from OpenStreetMap with Postgis and Java.