### PR TITLE
add ngx_http_mbtiles_module

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ data into vector tiles that can be rendered dynamically.
 - [SpatialServer (PGRestAPI)](https://github.com/spatialdev/PGRestAPI) - A multi-purpose GeoSpatial NodeJS web server created at [SpatialDev](http://spatialdev.com) that not only serves MBTiles stuffed with vector tiles, it can also cut vector tiles on the fly from a PostGIS database. [:warning:](https://github.com/spatialdev/PGRestAPI/issues/142#issuecomment-231132808) No longer maintained.
 - [Utilery](https://github.com/etalab/utilery) Server to generate vector tiles from PostGIS queries. Python based [:warning:](https://github.com/tilery/utilery/issues/6) no longer maintained.
 - [pg_tileserv](https://github.com/CrunchyData/pg_tileserv) - A very thin PostGIS-only tile server in Go. Takes in HTTP tile requests, executes SQL, returns MVT tiles.
+- [ngx_http_mbtiles_module](https://github.com/durkie/ngx_http_mbtiles_module) - Serve mbtiles files directly from nginx. Ideal for low-resource environments or situations where the mbtiles contents are changing frequently.
 
 ## Low-level utilities
 


### PR DESCRIPTION
Add link to ngx_http_mbtiles_module, which lets you serve mbtiles directly from nginx.