### PR TITLE
Adds Tegola OSM/OMT Import Procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ data into vector tiles that can be rendered dynamically.
 - [Build Your Own Static Vector Tile Pipeline](https://geovation.github.io/build-your-own-static-vector-tile-pipeline) - guide transforming, encoding and hosting tiles in the cloud; using ogr2ogr + tippecanoe + Mapbox GL JS
 - [Using the new MVT function in PostGIS](https://medium.com/nycplanninglabs/using-the-new-mvt-function-in-postgis-75f8addc1d68) - Building a vector tile service with PostGIS, express, and pg-promise.
 - [Serverless Vector Tiles on AWS](https://github.com/addresscloud/serverless-tiles)
+- [Tegola OSM/OMT Import Procedure](https://github.com/dechristopher/tegola-omt) - This document outlines everything necessary to build, from scratch, an operational OpenStreetMap vector tile server. The stack consists of the latest LTS Ubuntu Server distribution, Tegola as the tile server, PostgreSQL as the database, and the use of the open source OpenMapTiles standard schema.
 
 ## License
 


### PR DESCRIPTION
This repo outlines everything necessary to build, from scratch, an operational OpenStreetMap vector tile server. The stack consists of the latest LTS Ubuntu Server distribution, Tegola as the tile server, PostgreSQL as the database, and the use of the open source OpenMapTiles standard schema.